### PR TITLE
Fix ticket login and updates the gitfusion to latest version

### DIFF
--- a/git-fusion/Dockerfile
+++ b/git-fusion/Dockerfile
@@ -11,6 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 RUN apt-get install -yq --no-install-recommends -q wget python openssh-server patch
+RUN apt-get install -yq --no-install-recommends -q iproute2 net-tools
 
 # Add official perforce packages
 RUN wget -qO - https://package.perforce.com/perforce.pubkey | apt-key add -

--- a/git-fusion/Dockerfile
+++ b/git-fusion/Dockerfile
@@ -1,7 +1,7 @@
 FROM phusion/baseimage:0.9.18
 MAINTAINER Jim Tilander <jim@tilander.org>
 
-ENV FUSION_VERSION 2017.1-1484925~trust
+ENV FUSION_VERSION 2017.2-1590471~trusty
 
 # Use the base image's standard init process
 CMD ["/sbin/my_init"]

--- a/git-fusion/Dockerfile
+++ b/git-fusion/Dockerfile
@@ -1,7 +1,7 @@
-FROM phusion/baseimage:0.9.18
+FROM phusion/baseimage:0.10.2
 MAINTAINER Jim Tilander <jim@tilander.org>
 
-ENV FUSION_VERSION 2017.2-1590471~trusty
+ENV FUSION_VERSION 2017.2-1590471~xenial
 
 # Use the base image's standard init process
 CMD ["/sbin/my_init"]
@@ -14,7 +14,7 @@ RUN apt-get install -yq --no-install-recommends -q wget python openssh-server pa
 
 # Add official perforce packages
 RUN wget -qO - https://package.perforce.com/perforce.pubkey | apt-key add -
-RUN echo 'deb http://package.perforce.com/apt/ubuntu trusty release' > /etc/apt/sources.list.d/perforce.list
+RUN echo 'deb http://package.perforce.com/apt/ubuntu xenial release' > /etc/apt/sources.list.d/perforce.list
 RUN apt-get update
 
 RUN apt-cache policy helix-git-fusion

--- a/git-fusion/init-git-fusion.sh
+++ b/git-fusion/init-git-fusion.sh
@@ -73,7 +73,7 @@ cp /etc/ssh/ssh_host* /data/sshkeys/
 echo "Waiting for the perforce server to come up..."
 sleep 3
 
-P4TICKET=`echo "$P4PASSWD"|/usr/bin/p4 login -a -p|sed -r -e "s/Enter password://g"`
+P4TICKET=`echo "$P4PASSWD"|/usr/bin/p4 login -a -p $P4USER|sed -r -e "s/Enter password://g"`
 echo $P4TICKET
 P4="/usr/bin/p4 -u $P4USER -p $P4PORT -P $P4TICKET"
 

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,7 +1,7 @@
-FROM phusion/baseimage:0.9.18
+FROM phusion/baseimage:0.10.2
 MAINTAINER Jim Tilander <jim@tilander.org>
 
-ENV P4P_VERSION 15.2
+ENV P4P_VERSION 17.2
 
 # Use the base image's standard init process
 CMD ["/sbin/my_init"]
@@ -14,7 +14,7 @@ RUN apt-get install -yq --no-install-recommends -q wget python gettext-base
 
 # Add official perforce packages
 RUN wget -qO - https://package.perforce.com/perforce.pubkey | apt-key add -
-RUN echo 'deb http://package.perforce.com/apt/ubuntu trusty release' > /etc/apt/sources.list.d/perforce.list
+RUN echo 'deb http://package.perforce.com/apt/ubuntu xenial release' > /etc/apt/sources.list.d/perforce.list
 RUN apt-get update
 
 RUN apt-get install -yq --no-install-recommends -q helix-cli

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
-FROM phusion/baseimage:0.9.18
+FROM phusion/baseimage:0.10.2
 MAINTAINER Jim Tilander <jim@tilander.org>
 
-ENV P4D_VERSION 2016.2-1487173~trusty
+ENV P4D_VERSION 2017.2-1760971~xenial
 
 # Use the base image's standard init process
 CMD ["/sbin/my_init"]
@@ -14,12 +14,12 @@ RUN apt-get install -yq --no-install-recommends -q wget python gettext-base
 
 # Add official perforce packages
 RUN wget -qO - https://package.perforce.com/perforce.pubkey | apt-key add -
-RUN echo 'deb http://package.perforce.com/apt/ubuntu trusty release' > /etc/apt/sources.list.d/perforce.list
+RUN echo 'deb http://package.perforce.com/apt/ubuntu xenial release' > /etc/apt/sources.list.d/perforce.list
 RUN apt-get update
 
 RUN apt-cache policy helix-p4d
 
-RUN apt-get install -yq --no-install-recommends -q helix-cli helix-p4d=$P4D_VERSION helix-p4dctl helix-git-fusion-trigger
+RUN apt-get install -yq --no-install-recommends -q helix-cli helix-p4d=$P4D_VERSION helix-p4d-base=$P4D_VERSION helix-p4dctl helix-git-fusion-trigger
 
 # Cleanup APT when we are done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
I was not able to authenticate setting `$P4PASSWD` to a ticket but this change should allow the docker image to work.

Also, while rebuilding the image I also upgraded the gitfusion sources to latest. We can do the same for the base image but it was more work to find one that is still based on trusty or maximum xenial.